### PR TITLE
Make Preprocessor.php compatible with PHP 8.1

### DIFF
--- a/SwaggerGen/Parser/Php/Preprocessor.php
+++ b/SwaggerGen/Parser/Php/Preprocessor.php
@@ -49,7 +49,7 @@ class Preprocessor extends \SwaggerGen\Parser\AbstractPreprocessor
 				switch ($token[0]) {
 					case T_DOC_COMMENT:
 					case T_COMMENT:
-						foreach (preg_split('/(\\R)/m', $token[1], null, PREG_SPLIT_DELIM_CAPTURE) as $index => $line) {
+						foreach (preg_split('/(\\R)/m', $token[1], -1, PREG_SPLIT_DELIM_CAPTURE) as $index => $line) {
 							if ($index % 2) {
 								$output .= $line;
 							} else {


### PR DESCRIPTION
Passing null to parameter #3 of preg_split is deprecated in PHP 8.1: use limit=-1 instead.